### PR TITLE
Add Ruby-2.2.0 to travisCI test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: ruby
 rvm:
+  - 2.2.0
   - 2.3.0
   - 2.4.0
 before_install: gem install bundler -v 1.14.6


### PR DESCRIPTION
現在メンテナンスされている Ruby のバージョン全てで CI するようにした。

https://www.ruby-lang.org/ja/downloads/

Library Gem の CI は Travis が良い。