### PR TITLE
Bump ruby versions in Travis CI

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,5 +19,8 @@ Style/FormatString:
 Style/FormatStringToken:
   EnforcedStyle: unannotated
 
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
+  Enabled: false
+
+Style/TrailingCommaInHashLiteral:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ AllCops:
     - Rakefile
     - bin/*
     - vendor/**/*
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.2
 
 Metrics/BlockLength:
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,7 @@ AllCops:
     - Rakefile
     - bin/*
     - vendor/**/*
+  TargetRubyVersion: 2.3
 
 Metrics/BlockLength:
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ AllCops:
     - Rakefile
     - bin/*
     - vendor/**/*
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.3
 
 Metrics/BlockLength:
   Exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,6 @@ rvm:
   - 2.4.4
   - 2.3.7
 before_install: gem install bundler -v 1.16.1
-before_script: bundle exec rubocop
+before_script:
+  - ./bin/validate-target-ruby-version.rb
+  - bundle exec rubocop

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.2.9
-  - 2.3.6
-  - 2.4.3
-  - 2.5.0
+  - 2.5.1
+  - 2.4.4
+  - 2.3.7
 before_install: gem install bundler -v 1.16.1
 before_script: bundle exec rubocop

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in useragent_api.gemspec

--- a/bin/validate-target-ruby-version.rb
+++ b/bin/validate-target-ruby-version.rb
@@ -1,0 +1,10 @@
+#!/usr/bin/env ruby
+
+require 'yaml'
+
+# rubocop's TargetRubyVersion should be the oldest version in .travis.yml
+
+target = YAML.load_file('.rubocop.yml')['AllCops']['TargetRubyVersion'].to_s
+oldest = YAML.load_file('.travis.yml')['rvm'].min
+
+exit 1 unless oldest.start_with?(target)

--- a/lib/useragent_api.rb
+++ b/lib/useragent_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'useragent_api/version'
 
 # :nodoc:

--- a/lib/useragent_api/client.rb
+++ b/lib/useragent_api/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cgi'
 require 'json'
 require 'net/https'

--- a/lib/useragent_api/version.rb
+++ b/lib/useragent_api/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module UseragentApi
-  VERSION = '0.1.2'.freeze
+  VERSION = '0.1.2'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/setup'
 require 'useragent_api'
 require 'webmock/rspec'

--- a/spec/useragent_api/client_spec.rb
+++ b/spec/useragent_api/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe UseragentApi::Client do
   describe '#initialize' do
     let(:client) { UseragentApi::Client.new(api_key) }

--- a/useragent_api.gemspec
+++ b/useragent_api.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'useragent_api/version'

--- a/useragent_api.gemspec
+++ b/useragent_api.gemspec
@@ -1,4 +1,4 @@
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'useragent_api/version'
 


### PR DESCRIPTION
## Why?

https://www.ruby-lang.org/en/news/2018/03/28/ruby-2-2-10-released/

> Ruby 2.2 is under the state of the security maintenance phase, until the end of the March of 2018. After the date, maintenance of Ruby 2.2 will be ended. So, this release is expected to be the last release of Ruby 2.2. We will never make a new release of Ruby 2.2 unless Ruby 2.2.10 has a serious regression bug. We recommend you migrating to newer versions of Ruby, such as 2.5.

## How?

I updated ruby versions in .travis.yml. And I added TargetRubyVersion to .rubocop.yml and the validater `bin/validate-target-ruby-version.rb`.
